### PR TITLE
Bug: Fix template vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-singlestat-panel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Simple Angular Grafana",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,7 +24,7 @@ import {
   locationUtil,
   getFieldDisplayName,
   getColorForTheme,
-  InterpolateFunction
+  InterpolateFunction,
 } from '@grafana/data';
 
 import { convertOldAngularValueMapping } from '@grafana/ui';
@@ -619,7 +619,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       elem.toggleClass('pointer', panel.links.length > 0);
 
       if (panel.links.length > 0) {
-        const replace: InterpolateFunction = (value, vars, fmt) => this.templateSrv.replace(value, { ...data.scopedVars, ...vars }, fmt);
+        const replace: InterpolateFunction = (value, vars, fmt) =>
+          this.templateSrv.replace(value, { ...data.scopedVars, ...vars }, fmt);
 
         linkInfo = linkSrv.getDataLinkUIModel(panel.links[0], replace, {});
       } else {

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,6 +24,7 @@ import {
   locationUtil,
   getFieldDisplayName,
   getColorForTheme,
+  InterpolateFunction
 } from '@grafana/data';
 
 import { convertOldAngularValueMapping } from '@grafana/ui';
@@ -618,7 +619,9 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       elem.toggleClass('pointer', panel.links.length > 0);
 
       if (panel.links.length > 0) {
-        linkInfo = linkSrv.getDataLinkUIModel(panel.links[0], data.scopedVars, {});
+        const replace: InterpolateFunction = (value, vars, fmt) => this.templateSrv.replace(value, { ...data.scopedVars, ...vars }, fmt);
+
+        linkInfo = linkSrv.getDataLinkUIModel(panel.links[0], replace, {});
       } else {
         linkInfo = null;
       }


### PR DESCRIPTION
Singlestat panel is using `linkSrv.getDataLinkUIModel` to return a `DataLink` with values interpolated via templateSrv. However it was passing the `scopedVars` where `getDataLinkUIModel` is expecting an `InterpolateFunction`. This causes the JS to error in certain conditions and the image renderer plugin to timeout when trying to render the panel.

Tested in Grafana 7.3.0 and 8.3.6 and appears to work as expected.

